### PR TITLE
解决因变量为初始化 / 检测方式不正确导致的变量不存在错误!

### DIFF
--- a/Gateway.php
+++ b/Gateway.php
@@ -1287,6 +1287,7 @@ class Gateway
         $time_now = time();
         $expiration_time = 1;
         $register_addresses = (array)static::$registerAddress;
+        $client = null;
         if(empty($addresses_cache) || $time_now - $last_update > $expiration_time) {
             foreach ($register_addresses as $register_address) {
                 set_error_handler(function(){});


### PR DESCRIPTION
有幸旧项目中使用到了这个类库，在运行时发现了一些问题，虽然这个问题在正确的配置下不会出现，但是也不失为意外情况。

![image](https://user-images.githubusercontent.com/31845646/54664101-357d0a80-4b1e-11e9-9abd-b829978dd770.png)
